### PR TITLE
commit changes in date format using dayjs package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.7",
+        "dayjs": "^1.11.13",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0"
@@ -2075,6 +2076,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "dayjs": "^1.11.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0"

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -3,6 +3,11 @@ import { getPost } from "../api/PostAPI";
 import { FaStar } from "react-icons/fa";
 import { GoIssueClosed } from "react-icons/go";
 import { BiTime } from "react-icons/bi";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+
+// Initialize the relative time plugin using dayjs package
+dayjs.extend(relativeTime);
 
 interface Repository {
   id: number;
@@ -30,20 +35,7 @@ const Post = (): JSX.Element => {
   }, []);
 
   const formatDate = (dateString: string): string => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffTime = Math.abs(now.getTime() - date.getTime());
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    const diffMonths = Math.floor(diffDays / 30);
-    const diffYears = Math.floor(diffDays / 365);
-
-    if (diffDays < 30) {
-      return `${diffDays} days ago`;
-    } else if (diffMonths < 12) {
-      return `${diffMonths} months ago`;
-    } else {
-      return `${diffYears} years ago`;
-    }
+    return dayjs(dateString).fromNow();
   };
 
   return (
@@ -51,9 +43,7 @@ const Post = (): JSX.Element => {
       <section className="container mx-auto px-4">
       <h2 className="text-3xl font-bold text-gray-800 mb-8 text-center relative before:absolute before:bottom-0 before:h-1 before:w-48 before:left-1/2 before:-translate-x-1/2 before:bg-blue-500 before:rounded-full pb-2 hover:before:w-96 before:transition-all">
   GitHub Repositories
-</h2>
-
-        <ul className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+</h2>        <ul className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {data.map((repo) => (
             <li
               key={repo.id}


### PR DESCRIPTION
Added dayjs and its relative time plugin
Simplified the formatDate function to use dayjs's fromNow() method
The output will be more accurate and will show formats like:
"a few seconds ago"
"2 minutes ago"
"3 hours ago"
"5 days ago"
"2 months ago"
"1 year ago"
This implementation is more concise and provides better internationalization support if needed in the future.